### PR TITLE
Updated for qt creator 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Color scheme for syntax based on Atom One Dark colors
 
 ![Sample](img/sample.png)
 
-### Activating Theme
+## Activating Theme
+### Linux
 1. Copy `one_dark.xml` into `~/.config/QtProject/qtcreator/styles`
 2. In Qt Creator: `Tools->Options->Text Editor->Font & Colors` and select `Atom One Dark` scheme 
+
+### Windows
+1. Copy `one_dark.xml` into `%appdata%\QtProject\qtcreator\styles`
+2. In Qt Creator: `Tools->Options->Text Editor->Font & Colors` and select `Atom One Dark` scheme 
+
+## Last tested version
+Qt Creator 12.0.1

--- a/one_dark.xml
+++ b/one_dark.xml
@@ -5,6 +5,9 @@
   <style name="Selection" background="#3e4451"/>
   <style name="LineNumber" foreground="#4b5363"/>
   <style name="SearchResult" background="#324365"/>
+  <style name="SearchResultAlt1" foreground="#000033" background="#b6ccff"/>
+  <style name="SearchResultAlt2" foreground="#330000" background="#ffb6cc"/>
+  <style name="SearchResultContainingFunction"/>
   <style name="SearchScope" background="#3e4451"/>
   <style name="Parentheses" underlineColor="#61afef" underlineStyle="SingleUnderline"/>
   <style name="ParenthesesMismatch" foreground="#000000" background="#c678dd"/>
@@ -16,8 +19,11 @@
   <style name="Occurrences.Rename" background="#e06c75"/>
   <style name="Number" foreground="#d19a66"/>
   <style name="String" foreground="#98c379"/>
-  <style name="Type" foreground="#61afef"/>
-  <style name="Local"/>
+  <style name="Type" foreground="#e5c07b"/>
+  <style name="Concept" foreground="#61afef"/>
+  <style name="Namespace" foreground="#61afef"/>
+  <style name="Local" foreground="#e06c75"/>
+  <style name="Parameter" foreground="#e06c75"/>
   <style name="Global"/>
   <style name="Field" foreground="#e06c75"/>
   <style name="Static" foreground="#61afef" italic="true"/>
@@ -29,6 +35,7 @@
   <style name="Overloaded Operator" foreground="#c678dd"/>
   <style name="Punctuation"/>
   <style name="Preprocessor" foreground="#c678dd"/>
+  <style name="Macro" foreground="#61afef"/>
   <style name="Label" foreground="#e06c75" bold="true"/>
   <style name="Comment" foreground="#5c6370" italic="true"/>
   <style name="Doxygen.Comment" foreground="#5c6370" italic="true"/>
@@ -36,7 +43,7 @@
   <style name="VisualWhitespace" foreground="#3c4049"/>
   <style name="QmlLocalId" foreground="#61afef"/>
   <style name="QmlExternalId"/>
-  <style name="QmlTypeId" foreground="#61afef"/>
+  <style name="QmlTypeId" foreground="#e5c07b"/>
   <style name="QmlRootObjectProperty" foreground="#61afef"/>
   <style name="QmlScopeObjectProperty" foreground="#61afef"/>
   <style name="QmlExternalObjectProperty"/>
@@ -69,5 +76,16 @@
   <style name="Declaration"/>
   <style name="FunctionDefinition"/>
   <style name="OutputArgument" italic="true"/>
+  <style name="StaticMember"/>
+  <style name="CocoCodeAdded"/>
+  <style name="CocoPartiallyCovered" foreground="#808000"/>
+  <style name="CocoNotCovered" foreground="#ff0000"/>
+  <style name="CocoFullyCovered" foreground="#00ff00"/>
+  <style name="CocoManuallyValidated" foreground="#0000ff"/>
+  <style name="CocoDeadCode" foreground="#ff00ff"/>
+  <style name="CocoExecutionCountTooLow" foreground="#ff0000"/>
+  <style name="CocoNotCoveredInfo" foreground="#ff0000"/>
+  <style name="CocoCoveredInfo" foreground="#00ff00"/>
+  <style name="CocoManuallyValidatedInfo" foreground="#0000ff"/>
   <style name="LastStyleSentinel"/>
 </style-scheme>


### PR DESCRIPTION
Thanks for this theme, I found it closest to the original Atom One dark, and I don't want it to be just become stale. Some minor tweaks for latest qt creator version, and make type name to a yellow-ish color instead of blue. (Value copied from Visual Studio)